### PR TITLE
Set font color based on theme

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -40,7 +40,7 @@ export default function RootLayout({ children }) {
           }}
         />
       </head>
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased text-black dark:text-white`}>
         {children}
       </body>
     </html>


### PR DESCRIPTION
Add global default font color to be black in light mode and white in dark mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-09dcf9aa-a243-4639-87a1-189cb36731a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-09dcf9aa-a243-4639-87a1-189cb36731a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

